### PR TITLE
Apply prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 Script contains object expression. You can use it for configs, network packets,
 serialization format, etc.
+
 ```js
 const metavm = require('metavm');
 
@@ -27,6 +28,7 @@ console.log(ms);
 
 Script contains function expression. You can use it for api endpoints, domain
 logic stored in files or database, etc.
+
 ```js
 const metavm = require('metavm');
 

--- a/dist/metavm.js
+++ b/dist/metavm.js
@@ -1,2 +1,1 @@
-export class MetaScript {
-}
+export class MetaScript {}

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -7,9 +7,10 @@ const vm = require('./vm.js');
 const readScript = async (filePath, options) => {
   const src = await fs.readFile(filePath, 'utf8');
   if (!src) return null;
-  const name = options && options.filename
-    ? options.filename
-    : path.basename(filePath, '.js');
+  const name =
+    options && options.filename
+      ? options.filename
+      : path.basename(filePath, '.js');
   const script = new vm.MetaScript(name, src, options);
   return script;
 };

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -4,18 +4,29 @@ const vm = require('vm');
 
 const RUN_OPTIONS = { timeout: 5000, displayErrors: false };
 const CONTEXT_OPTIONS = { microtaskMode: 'afterEvaluate' };
-const USE_STRICT = '\'use strict\';\n';
+const USE_STRICT = `'use strict';\n`;
 
 const EMPTY_CONTEXT = vm.createContext(Object.freeze({}));
 
-const COMMON_CONTEXT = vm.createContext(Object.freeze({
-  Buffer, URL, URLSearchParams, TextDecoder, TextEncoder,
-  console, queueMicrotask,
-  setTimeout, setImmediate, setInterval,
-  clearTimeout, clearImmediate, clearInterval,
-}));
+const COMMON_CONTEXT = vm.createContext(
+  Object.freeze({
+    Buffer,
+    URL,
+    URLSearchParams,
+    TextDecoder,
+    TextEncoder,
+    console,
+    queueMicrotask,
+    setTimeout,
+    setImmediate,
+    setInterval,
+    clearTimeout,
+    clearImmediate,
+    clearInterval,
+  })
+);
 
-const createContext = context => {
+const createContext = (context) => {
   if (!context) return EMPTY_CONTEXT;
   return vm.createContext(context, CONTEXT_OPTIONS);
 };

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "url": "https://github.com/metarhia/metavm/issues"
   },
   "scripts": {
-    "lint": "eslint . && prettier --check \"**/*.js\" \"**/*.json\" \"**/*.md\" \"**/.*rc\" \"**/*.yml\" \"**/*.ts\"",
-    "fmt": "prettier --write \"**/*.js\" \"**/*.json\" \"**/*.md\" \"**/.*rc\" \"**/*.yml\" \"**/*.ts\"",
+    "lint": "eslint . && prettier --check \"**/*.js\" \"**/*.json\" \"**/*.md\" \"**/.*rc\" \"**/*.yml\"",
+    "fmt": "prettier --write \"**/*.js\" \"**/*.json\" \"**/*.md\" \"**/.*rc\" \"**/*.yml\"",
     "types": "tsc -p types/tsconfig.json",
     "test": "eslint . && metatests test/"
   },

--- a/test/examples/undef.js
+++ b/test/examples/undef.js
@@ -1,4 +1,4 @@
-async data => {
+async (data) => {
   const result = data.unknownKey();
   return result;
 };

--- a/test/unit.js
+++ b/test/unit.js
@@ -6,7 +6,7 @@ const metatests = require('metatests');
 
 const examples = path.join(__dirname, 'examples');
 
-metatests.test('MetaScript constructor', async test => {
+metatests.test('MetaScript constructor', async (test) => {
   const src = `({ field: 'value' });`;
   const ms = new metavm.MetaScript('Example', src);
 
@@ -22,7 +22,7 @@ metatests.test('MetaScript constructor', async test => {
   test.end();
 });
 
-metatests.test('MetaScript factory', async test => {
+metatests.test('MetaScript factory', async (test) => {
   const src = `({ field: 'value' });`;
   const ms = metavm.createScript('Example', src);
 
@@ -38,7 +38,7 @@ metatests.test('MetaScript factory', async test => {
   test.end();
 });
 
-metatests.test('Load script', async test => {
+metatests.test('Load script', async (test) => {
   const filePath = path.join(examples, 'simple.js');
   const ms = await metavm.readScript(filePath);
 
@@ -56,11 +56,11 @@ metatests.test('Load script', async test => {
   test.end();
 });
 
-metatests.test('Load script with context and options', test => {
+metatests.test('Load script with context and options', (test) => {
   const filePath = path.join(examples, 'complex.js');
   const context = metavm.createContext({ setTimeout });
   const options = { filename: 'CUSTOM FILE NAME', context };
-  metavm.readScript(filePath, options).then(ms => {
+  metavm.readScript(filePath, options).then((ms) => {
     test.strictSame(ms.constructor.name, 'MetaScript');
     ms.exports.add(2, 3, (err, sum) => {
       test.strictSame(err.constructor.name === 'Error', true);
@@ -72,7 +72,7 @@ metatests.test('Load script with context and options', test => {
   });
 });
 
-metatests.test('Load function', async test => {
+metatests.test('Load function', async (test) => {
   const filePath = path.join(examples, 'function.js');
   const ms = await metavm.readScript(filePath);
 
@@ -86,7 +86,7 @@ metatests.test('Load function', async test => {
   test.end();
 });
 
-metatests.test('Load arrow function', async test => {
+metatests.test('Load arrow function', async (test) => {
   const filePath = path.join(examples, 'arrow.js');
   const ms = await metavm.readScript(filePath);
 
@@ -97,7 +97,7 @@ metatests.test('Load arrow function', async test => {
   test.end();
 });
 
-metatests.test('Load async function', async test => {
+metatests.test('Load async function', async (test) => {
   const filePath = path.join(examples, 'async.js');
   const ms = await metavm.readScript(filePath);
 
@@ -112,7 +112,7 @@ metatests.test('Load async function', async test => {
   test.end();
 });
 
-metatests.test('File is not found', async test => {
+metatests.test('File is not found', async (test) => {
   const filePath = path.join(examples, 'notfound.js');
   let ms;
   try {
@@ -124,7 +124,7 @@ metatests.test('File is not found', async test => {
   test.end();
 });
 
-metatests.test('Syntax error', async test => {
+metatests.test('Syntax error', async (test) => {
   const filePath = path.join(examples, 'syntax.error');
   let ms;
   try {
@@ -136,14 +136,14 @@ metatests.test('Syntax error', async test => {
   test.end();
 });
 
-metatests.test('Create default context', async test => {
+metatests.test('Create default context', async (test) => {
   const context = metavm.createContext();
   test.strictSame(Object.keys(context), []);
   test.strictSame(context.global, undefined);
   test.end();
 });
 
-metatests.test('Create common context', async test => {
+metatests.test('Create common context', async (test) => {
   const context = metavm.createContext(metavm.COMMON_CONTEXT);
   test.strictSame(typeof context, 'object');
   test.strictSame(context.console, console);
@@ -151,7 +151,7 @@ metatests.test('Create common context', async test => {
   test.end();
 });
 
-metatests.test('Create custom context', async test => {
+metatests.test('Create custom context', async (test) => {
   const sandbox = { field: 'value' };
   sandbox.global = sandbox;
   const context = metavm.createContext(sandbox);
@@ -161,7 +161,7 @@ metatests.test('Create custom context', async test => {
   test.end();
 });
 
-metatests.test('Call undefined as a function', async test => {
+metatests.test('Call undefined as a function', async (test) => {
   const filePath = path.join(examples, 'undef.js');
   const ms = await metavm.readScript(filePath);
 


### PR DESCRIPTION
- [x] code is properly formatted (`npm run fmt`)
