### PR TITLE
Add sandboxed context parameter preventEscape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ First metavm implementation with following features
 - Loader script from file with timeout and error handling
 - Add `use strict` if it's not found, fix line offset
 - Contexts, use default empty and frozen, emulated or pass one
+- Use `microtaskMode` https://github.com/nodejs/node/pull/34023
 
 [unreleased]: https://github.com/metarhia/metavm/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/metarhia/metavm/releases/tag/v0.1.0

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -26,9 +26,9 @@ const COMMON_CONTEXT = vm.createContext(
   })
 );
 
-const createContext = (context) => {
+const createContext = (context, preventEscape = false) => {
   if (!context) return EMPTY_CONTEXT;
-  return vm.createContext(context, CONTEXT_OPTIONS);
+  return vm.createContext(context, preventEscape ? CONTEXT_OPTIONS : {});
 };
 
 class MetaScript {


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm run t`)
- [x] code is properly formatted (`npm run fmt`)
