### PR TITLE
WIP: Add metavm types

### DIFF
--- a/metavm.d.ts
+++ b/metavm.d.ts
@@ -1,0 +1,38 @@
+import * as vm from 'vm';
+
+export const createContext: (
+  context?: vm.Context,
+  preventEscape?: boolean
+) => vm.Context;
+
+export interface MetaScriptOptions
+  extends Omit<vm.ScriptOptions, 'filename' | 'lineOffset'> {
+  context: vm.Context;
+}
+
+export class MetaScript {
+  name: string;
+  script: vm.Script;
+  context: vm.Context;
+  exports: any;
+  constructor(name: string, src: string, options?: MetaScriptOptions);
+}
+
+export const createScript: (
+  name: string,
+  src: string,
+  options?: MetaScriptOptions
+) => MetaScript;
+
+export const EMPTY_CONTEXT: vm.Context;
+export const COMMON_CONTEXT: vm.Context;
+
+export interface ReadScriptOptions
+  extends Omit<vm.ScriptOptions, 'lineOffset'> {
+  context?: vm.Context;
+}
+
+export const readScript: (
+  filePath: string,
+  options?: ReadScriptOptions
+) => Promise<MetaScript>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,12 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "@types/node": {
+      "version": "14.14.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.27.tgz",
+      "integrity": "sha512-Ecfmo4YDQPwuqTCl1yBxLV5ihKfRlkBmzUEDcfIRvDxOTGQEeikr317Ln7Gcv0tjA8dVgKI3rniqW2G1OyKDng==",
+      "dev": true
+    },
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "isolation"
   ],
   "main": "metavm.js",
+  "types": "metavm.d.ts",
   "browser": {
     "./metavm.js": "./dist/metavm.js"
   },
@@ -44,6 +45,7 @@
     "test": "eslint . && metatests test/"
   },
   "devDependencies": {
+    "@types/node": "^14.14.27",
     "eslint": "^7.15.0",
     "eslint-config-metarhia": "^7.0.1",
     "eslint-config-prettier": "^7.0.0",


### PR DESCRIPTION
Added types to the library.
Couldn't find how metarhia usually does .d.ts files, so I will be happy to redo them if you want another style.

Resolves #28 

- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)