### PR TITLE
Require context bounded

### DIFF
--- a/lib/vm.js
+++ b/lib/vm.js
@@ -26,9 +26,17 @@ const COMMON_CONTEXT = vm.createContext(
   })
 );
 
+const contextifiedRequire = (context) => (module) => {
+  if (Reflect.has(context, module)) return Reflect.get(context, module);
+  return undefined;
+};
+
 const createContext = (context, preventEscape = false) => {
   if (!context) return EMPTY_CONTEXT;
-  return vm.createContext(context, preventEscape ? CONTEXT_OPTIONS : {});
+  return vm.createContext(
+    { ...context, require: contextifiedRequire(context) },
+    preventEscape ? CONTEXT_OPTIONS : {}
+  );
 };
 
 class MetaScript {

--- a/test/unit.js
+++ b/test/unit.js
@@ -156,8 +156,19 @@ metatests.test('Create custom context', async (test) => {
   sandbox.global = sandbox;
   const context = metavm.createContext(sandbox);
   test.strictSame(context.field, 'value');
-  test.strictSame(Object.keys(context), ['field', 'global']);
+  test.strictSame(Object.keys(context), ['field', 'global', 'require']);
   test.strictSame(context.global, sandbox);
+  test.end();
+});
+
+metatests.test('Require binded to custom context', async (test) => {
+  const sandbox = { field: 'value' };
+  sandbox.global = sandbox;
+  const context = metavm.createContext(sandbox);
+  const src = `({ exist: require('field'), notExist: require('nothing') })`;
+  const ms = metavm.createScript('Example', src, { context });
+  test.strictSame('value', ms.exports.exist);
+  test.strictSame(undefined, ms.exports.notExist);
   test.end();
 });
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->
Fix: #34 
Now when context created `require` bounding to this context using closure, when `require` called in vm it gets value from context with `Reflect`  if it exists.

- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
