### PR TITLE
Metarequire added

### DIFF
--- a/lib/vm.js
+++ b/lib/vm.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const fs = require('fs');
 const vm = require('vm');
 
 const RUN_OPTIONS = { timeout: 5000, displayErrors: false };
@@ -46,7 +47,19 @@ class MetaScript {
 
 const createScript = (name, src, options) => new MetaScript(name, src, options);
 
+const metarequire = (context) => (module) => {
+  if (Reflect.has(context, module)) return Reflect.get(context, module);
+  try {
+    const src = fs.readFileSync(module, 'utf8');
+    const script = createScript(module, src, { context });
+    return script;
+  } catch (error) {
+    return undefined;
+  }
+};
+
 module.exports = {
+  metarequire,
   createContext,
   MetaScript,
   createScript,

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lint": "eslint . && prettier -c \"**/*.js\" \"**/*.json\" \"**/*.md\" \"**/.*rc\" \"**/*.ts\"",
     "types": "tsc -p types/tsconfig.json",
     "fmt": "prettier --write \"**/*.js\" \"**/*.json\" \"**/*.md\" \"**/.*rc\" \"**/*.ts\"",
-    "test": "npm run lint && npm run types && metatests test/"
+    "test": "npm run lint && npm run types && metatests test/unit.js"
   },
   "devDependencies": {
     "@types/node": "^14.14.37",

--- a/test/examples/nestedmodule1.js
+++ b/test/examples/nestedmodule1.js
@@ -1,0 +1,7 @@
+/* eslint-disable */
+({
+  name: 'nestedmodule1',
+  value: 1,
+  mod: metarequire('./test/examples/nestedmodule2.js'),
+});
+/* eslint-enable */

--- a/test/examples/nestedmodule2.js
+++ b/test/examples/nestedmodule2.js
@@ -1,0 +1,6 @@
+/* eslint-disable */
+({
+  name: 'nestedmodule2',
+  value: 2,
+});
+/* eslint-enable */

--- a/test/unit.js
+++ b/test/unit.js
@@ -174,3 +174,21 @@ metatests.test('Call undefined as a function', async (test) => {
   }
   test.end();
 });
+
+metatests.test('Metarequire nestsed modules', async (test) => {
+  const context = { field: 'value' };
+  context.global = context;
+  context.metarequire = metavm.metarequire(context);
+  const metacontext = metavm.createContext(context);
+  const src = `({ 
+    field: metarequire('field'), 
+    notExist: metarequire('nothing'), 
+    mod: metarequire('./test/examples/nestedmodule1.js')
+  })`;
+  const ms = metavm.createScript('Example', src, { context: metacontext });
+  test.strictSame(ms.exports.field, 'value');
+  test.strictSame(ms.exports.notExist, undefined);
+  test.strictSame(ms.exports.mod.exports.value, 1);
+  test.strictSame(ms.exports.mod.exports.mod.exports.value, 2);
+  test.end();
+});


### PR DESCRIPTION
Function `metarequire` added. When we want to get module `metarequire('somelib')` it will look up for it in parent context using `Reflect`. When we require file creates new `Metascript` instance with same context, something like `metarequire('./nestedmodule.js')`. Example in [this test](https://github.com/AliusDieMorietur/metavm/blob/b4c5e69a25936b9ee9d7e855cb8d4894658529f7/test/unit.js#L178). Something like module1 -> require(fs) and even module1 -> require(module2) -> module2 -> require(fs) will work properly.

- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
