### PR TITLE
Optimize metarequire

### DIFF
--- a/metavm.js
+++ b/metavm.js
@@ -96,20 +96,20 @@ class MetaScript {
   createRequire() {
     const { context, type } = this;
     let { dirname, relative, access } = this;
+    const rel = (s) => CURDIR + path.relative(dirname, s);
     const require = (module) => {
       let name = module;
       let lib = this.checkAccess(name);
       if (lib instanceof Object) return lib;
       const npm = !name.includes('.');
       if (!npm) {
-        name = path.resolve(dirname, relative, module);
-        lib = this.checkAccess(CURDIR + path.relative(dirname, name));
+        name = path.resolve(dirname, relative, name);
+        lib = this.checkAccess(rel(name));
         if (lib instanceof Object) return lib;
-        const js = addExt(name);
-        name = name.startsWith('.') ? path.resolve(dirname, js) : js;
-        lib = this.checkAccess(CURDIR + path.relative(dirname, js));
+        lib = this.checkAccess(rel(addExt(name)));
         if (lib instanceof Object) return lib;
       }
+      console.log({ name });
       if (!lib) throw new MetavmError(`Access denied '${module}'`);
       try {
         const absolute = internalRequire.resolve(name);

--- a/metavm.js
+++ b/metavm.js
@@ -96,20 +96,16 @@ class MetaScript {
   createRequire() {
     const { context, type } = this;
     let { dirname, relative, access } = this;
-    const rel = (s) => CURDIR + path.relative(dirname, s);
     const require = (module) => {
       let name = module;
       let lib = this.checkAccess(name);
       if (lib instanceof Object) return lib;
       const npm = !name.includes('.');
       if (!npm) {
-        name = path.resolve(dirname, relative, name);
-        lib = this.checkAccess(rel(name));
-        if (lib instanceof Object) return lib;
-        lib = this.checkAccess(rel(addExt(name)));
+        name = path.resolve(dirname, relative, addExt(name));
+        lib = this.checkAccess(CURDIR + path.relative(dirname, name));
         if (lib instanceof Object) return lib;
       }
-      console.log({ name });
       if (!lib) throw new MetavmError(`Access denied '${module}'`);
       try {
         const absolute = internalRequire.resolve(name);

--- a/test/unit.js
+++ b/test/unit.js
@@ -302,7 +302,7 @@ metatests.test('Access non-existent module', async (test) => {
 metatests.test('Access nestsed commonjs', async (test) => {
   const sandbox = {};
   sandbox.global = sandbox;
-  const src = `module.exports = require('./examples/nestedmodule1.js');`;
+  const src = `module.exports = require('./examples/nestedmodule1');`;
   const ms = metavm.createScript('Example', src, {
     context: metavm.createContext(sandbox),
     dirname: __dirname,


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
