### PR TITLE
Add `node:` prefix in require for built-in modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Add `node:` prefix in require for built-in modules
+
 ## [1.2.2][] - 2022-11-16
 
 - Using optional chaining operator

--- a/metavm.js
+++ b/metavm.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const vm = require('vm');
-const fs = require('fs');
+const vm = require('node:vm');
+const fs = require('node:fs');
 const fsp = fs.promises;
-const path = require('path');
+const path = require('node:path');
 
 const USE_STRICT = `'use strict';\n`;
 const CURDIR = '.' + path.sep;

--- a/test/timeout.js
+++ b/test/timeout.js
@@ -1,8 +1,8 @@
 'use strict';
 
+const vm = require('node:vm');
+const assert = require('node:assert');
 const metavm = require('..');
-const vm = require('vm');
-const assert = require('assert');
 
 const TIMEOUT = 1000;
 

--- a/test/timeout.js
+++ b/test/timeout.js
@@ -49,7 +49,6 @@ const TIMEOUT = 1000;
     })
   });`;
   try {
-    //const context = metavm.createContext({}, true);
     const context = vm.createContext({}, { microtaskMode: 'afterEvaluate' });
     metavm.createScript('Example', src, { context });
     assert.fail(`${name}: failed`);

--- a/test/unit.js
+++ b/test/unit.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const metavm = require('..');
-const path = require('path');
+const path = require('node:path');
 const metatests = require('metatests');
+const metavm = require('..');
 
 const examples = path.join(__dirname, 'examples');
 

--- a/test/unit.js
+++ b/test/unit.js
@@ -137,12 +137,9 @@ metatests.test('Use local identifier', async (test) => {
   const context = metavm.createContext({});
   const filePath = path.join(examples, 'local.js');
   const ms1 = await metavm.readScript(filePath, { context });
-  const ms2 = await metavm.readScript(filePath, { context });
-  console.log({ ms1, ms2 });
 
   const expected = { args: ['str'], local: 'hello' };
   const result = await ms1.exports('str');
-  console.log({ result });
   test.strictSame(result, expected);
 
   test.end();


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
