### PR TITLE
Add support for requiring node internal modules with "node:" prefix

### DIFF
--- a/metavm.js
+++ b/metavm.js
@@ -4,6 +4,7 @@ const vm = require('node:vm');
 const fs = require('node:fs');
 const fsp = fs.promises;
 const path = require('node:path');
+const builtinModules = require('node:module').builtinModules;
 
 const CURDIR = '.' + path.sep;
 
@@ -143,6 +144,11 @@ class MetaScript {
     let { dirname, relative, access } = this;
     const require = (module) => {
       let name = module;
+      const builtin = name.startsWith('node:');
+      if (builtin) {
+        const builtinName = name.slice(5);
+        if (builtinModules.includes(builtinName)) return internalRequire(name);
+      }
       let lib = this.checkAccess(name);
       if (lib instanceof Object) return lib;
       const npm = !name.includes('.');

--- a/test/string.js
+++ b/test/string.js
@@ -80,6 +80,18 @@ test('Access for node internal module', async () => {
   assert.strictEqual(typeof ms.exports.fs.promises, 'object');
 });
 
+test('Access for node internal module with prefix', async () => {
+  const sandbox = {};
+  sandbox.global = sandbox;
+  const src = `'use strict'; module.exports = { fs: require('node:fs') };`;
+  const ms = metavm.createScript('Example', src, {
+    context: metavm.createContext(sandbox),
+    type: metavm.MODULE_TYPE.COMMONJS,
+  });
+  assert.strictEqual(typeof ms.exports, 'object');
+  assert.strictEqual(typeof ms.exports.fs.promises, 'object');
+});
+
 test('Access for stub module', async () => {
   const src = `
     'use strict';


### PR DESCRIPTION
<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

- [x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fix`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
#95 